### PR TITLE
Update LCD pinout for PCB fab B

### DIFF
--- a/electrical/apollo-ctrl-v4/ctrl-pico.brd
+++ b/electrical/apollo-ctrl-v4/ctrl-pico.brd
@@ -3,11 +3,11 @@
 <eagle version="9.6.2">
 <drawing>
 <settings>
-<setting alwaysvectorfont="no"/>
+<setting alwaysvectorfont="yes"/>
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.001" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="50" unitdist="mil" unit="mil" style="lines" multiple="1" display="no" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="yes"/>
@@ -1331,13 +1331,13 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <attribute name="NAME" x="83.058" y="12.2555" size="0.6096" layer="25" ratio="12"/>
 <attribute name="VALUE" x="82.804" y="10.033" size="0.6096" layer="27" ratio="12"/>
 </element>
-<element name="JP1" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" package3d_urn="urn:adsk.eagle:package:39277/1" value="BACKLIGHT" x="80.01" y="45.72" smashed="yes">
-<attribute name="NAME" x="80.01" y="46.863" size="0.6096" layer="25" font="vector" ratio="12" align="bottom-center"/>
-<attribute name="VALUE" x="76.835" y="45.847" size="0.6096" layer="27" font="vector" ratio="12" align="top-center"/>
+<element name="JP1" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" package3d_urn="urn:adsk.eagle:package:39277/1" value="BACKLIGHT" x="80.01" y="48.26" smashed="yes">
+<attribute name="NAME" x="80.01" y="49.403" size="0.6096" layer="25" font="vector" ratio="12" align="bottom-center"/>
+<attribute name="VALUE" x="76.835" y="48.387" size="0.6096" layer="27" font="vector" ratio="12" align="top-center"/>
 </element>
-<element name="JP2" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NC_PASTE_NO-SILK" package3d_urn="urn:adsk.eagle:package:39283/1" value="RESET" x="80.01" y="43.18" smashed="yes">
-<attribute name="NAME" x="80.01" y="44.323" size="0.6096" layer="25" font="vector" ratio="12" align="bottom-center"/>
-<attribute name="VALUE" x="77.47" y="43.307" size="0.6096" layer="27" font="vector" ratio="12" align="top-center"/>
+<element name="JP2" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NC_PASTE_NO-SILK" package3d_urn="urn:adsk.eagle:package:39283/1" value="RESET" x="80.01" y="45.72" smashed="yes">
+<attribute name="NAME" x="80.01" y="46.863" size="0.6096" layer="25" font="vector" ratio="12" align="bottom-center"/>
+<attribute name="VALUE" x="77.47" y="45.847" size="0.6096" layer="27" font="vector" ratio="12" align="top-center"/>
 </element>
 <element name="J6" library="SparkFun-Connectors" package="1X20" value="DISPLAY_RIGHT" x="83.82" y="25.4" smashed="yes" rot="R90">
 <attribute name="NAME" x="81.28" y="24.892" size="0.6096" layer="25" font="vector" ratio="12"/>
@@ -1481,7 +1481,7 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="55.88" y="74.295" extent="1-16" drill="0.45"/>
 <via x="58.42" y="43.815" extent="1-16" drill="0.45"/>
 <via x="59.69" y="64.135" extent="1-16" drill="0.45"/>
-<via x="76.835" y="44.45" extent="1-16" drill="0.45"/>
+<via x="76.835" y="49.53" extent="1-16" drill="0.45"/>
 <via x="21.59" y="26.67" extent="1-16" drill="0.45"/>
 <via x="24.13" y="26.67" extent="1-16" drill="0.45"/>
 <via x="27.305" y="23.495" extent="1-16" drill="0.45"/>
@@ -1491,15 +1491,15 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="2.54" y="11.43" extent="1-16" drill="0.45"/>
 <via x="5.08" y="70.485" extent="1-16" drill="0.45"/>
 <via x="36.83" y="20.32" extent="1-16" drill="0.45"/>
-<via x="34.29" y="34.29" extent="1-16" drill="0.45"/>
-<via x="36.83" y="31.75" extent="1-16" drill="0.45"/>
-<via x="36.83" y="36.83" extent="1-16" drill="0.45"/>
-<via x="44.45" y="36.83" extent="1-16" drill="0.45"/>
-<via x="46.99" y="39.37" extent="1-16" drill="0.45"/>
+<via x="34.29" y="36.83" extent="1-16" drill="0.45"/>
+<via x="36.83" y="34.29" extent="1-16" drill="0.45"/>
+<via x="36.83" y="39.37" extent="1-16" drill="0.45"/>
+<via x="44.45" y="39.37" extent="1-16" drill="0.45"/>
+<via x="46.99" y="41.91" extent="1-16" drill="0.45"/>
 <via x="81.28" y="34.29" extent="1-16" drill="0.45"/>
 <via x="81.28" y="36.83" extent="1-16" drill="0.45"/>
 <via x="81.28" y="31.75" extent="1-16" drill="0.45"/>
-<via x="81.28" y="29.21" extent="1-16" drill="0.45"/>
+<via x="81.28" y="41.91" extent="1-16" drill="0.45"/>
 <via x="81.28" y="39.37" extent="1-16" drill="0.45"/>
 <via x="76.835" y="46.99" extent="1-16" drill="0.45"/>
 <via x="41.91" y="15.875" extent="1-16" drill="0.45"/>
@@ -1519,27 +1519,27 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <signal name="SCK">
 <contactref element="U$1" pad="P$45"/>
 <contactref element="J1" pad="J3_11"/>
-<contactref element="J6" pad="3"/>
-<wire x1="38.1" y1="21.59" x2="38.1" y2="30.48" width="0.2032" layer="1"/>
-<wire x1="38.1" y1="30.48" x2="38.1" y2="73.79" width="0.2032" layer="1"/>
+<wire x1="38.1" y1="21.59" x2="38.1" y2="33.02" width="0.2032" layer="1"/>
+<wire x1="38.1" y1="33.02" x2="38.1" y2="73.79" width="0.2032" layer="1"/>
 <wire x1="38.1" y1="73.79" x2="40.64" y2="76.33" width="0.2032" layer="1"/>
-<wire x1="83.82" y1="30.48" x2="38.1" y2="30.48" width="0.2032" layer="16"/>
-<via x="38.1" y="30.48" extent="1-16" drill="0.45"/>
+<via x="38.1" y="33.02" extent="1-16" drill="0.45"/>
+<contactref element="J6" pad="4"/>
+<wire x1="38.1" y1="33.02" x2="83.82" y2="33.02" width="0.2032" layer="16"/>
 </signal>
 <signal name="CODI">
 <contactref element="U$1" pad="P$37"/>
 <contactref element="R9" pad="2"/>
 <contactref element="J1" pad="J3_12"/>
-<contactref element="J6" pad="5"/>
 <wire x1="35.56" y1="18.68" x2="35.56" y2="21.59" width="0.2032" layer="1"/>
 <wire x1="35.56" y1="71.755" x2="36.195" y2="72.39" width="0.2032" layer="1"/>
 <via x="36.195" y="72.39" extent="1-16" drill="0.45"/>
 <wire x1="36.195" y1="72.39" x2="35.56" y2="73.025" width="0.2032" layer="16"/>
 <wire x1="35.56" y1="73.025" x2="35.56" y2="76.33" width="0.2032" layer="16"/>
-<wire x1="35.56" y1="21.59" x2="35.56" y2="35.56" width="0.2032" layer="1"/>
-<wire x1="35.56" y1="35.56" x2="35.56" y2="71.755" width="0.2032" layer="1"/>
-<wire x1="83.82" y1="35.56" x2="35.56" y2="35.56" width="0.2032" layer="16"/>
-<via x="35.56" y="35.56" extent="1-16" drill="0.45"/>
+<wire x1="35.56" y1="21.59" x2="35.56" y2="38.1" width="0.2032" layer="1"/>
+<wire x1="35.56" y1="38.1" x2="35.56" y2="71.755" width="0.2032" layer="1"/>
+<via x="35.56" y="38.1" extent="1-16" drill="0.45"/>
+<contactref element="J6" pad="6"/>
+<wire x1="35.56" y1="38.1" x2="83.82" y2="38.1" width="0.2032" layer="16"/>
 </signal>
 <signal name="!LOE!">
 <contactref element="U$1" pad="P$29"/>
@@ -1631,13 +1631,13 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <contactref element="U$1" pad="P$41"/>
 <contactref element="J1" pad="J3_13"/>
 <contactref element="R15" pad="1"/>
-<contactref element="J6" pad="4"/>
 <wire x1="33.02" y1="18.68" x2="33.02" y2="21.59" width="0.2032" layer="1"/>
-<wire x1="33.02" y1="21.59" x2="33.02" y2="33.02" width="0.2032" layer="1"/>
-<wire x1="33.02" y1="33.02" x2="33.02" y2="71.25" width="0.2032" layer="1"/>
+<wire x1="33.02" y1="21.59" x2="33.02" y2="35.56" width="0.2032" layer="1"/>
+<wire x1="33.02" y1="35.56" x2="33.02" y2="71.25" width="0.2032" layer="1"/>
 <wire x1="33.02" y1="71.25" x2="38.1" y2="76.33" width="0.2032" layer="1"/>
-<wire x1="83.82" y1="33.02" x2="33.02" y2="33.02" width="0.2032" layer="16"/>
-<via x="33.02" y="33.02" extent="1-16" drill="0.45"/>
+<via x="33.02" y="35.56" extent="1-16" drill="0.45"/>
+<contactref element="J6" pad="5"/>
+<wire x1="83.82" y1="35.56" x2="33.02" y2="35.56" width="0.2032" layer="16"/>
 </signal>
 <signal name="CS1">
 <contactref element="U$1" pad="P$46"/>
@@ -1665,16 +1665,16 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <contactref element="U$1" pad="P$21"/>
 <contactref element="R12" pad="1"/>
 <contactref element="J1" pad="J3_8"/>
-<contactref element="J6" pad="6"/>
 <wire x1="45.72" y1="18.68" x2="45.72" y2="21.59" width="0.2032" layer="1"/>
-<wire x1="45.72" y1="21.59" x2="45.72" y2="38.1" width="0.2032" layer="1"/>
+<wire x1="45.72" y1="21.59" x2="45.72" y2="40.64" width="0.2032" layer="1"/>
 <via x="45.72" y="64.77" extent="1-16" drill="0.45"/>
-<wire x1="45.72" y1="38.1" x2="45.72" y2="64.77" width="0.2032" layer="1"/>
+<wire x1="45.72" y1="40.64" x2="45.72" y2="64.77" width="0.2032" layer="1"/>
 <wire x1="45.72" y1="64.77" x2="34.29" y2="64.77" width="0.2032" layer="16"/>
 <wire x1="34.29" y1="64.77" x2="25.4" y2="73.66" width="0.2032" layer="16"/>
 <wire x1="25.4" y1="73.66" x2="25.4" y2="76.33" width="0.2032" layer="16"/>
-<wire x1="83.82" y1="38.1" x2="45.72" y2="38.1" width="0.2032" layer="16"/>
-<via x="45.72" y="38.1" extent="1-16" drill="0.45"/>
+<via x="45.72" y="40.64" extent="1-16" drill="0.45"/>
+<contactref element="J6" pad="7"/>
+<wire x1="83.82" y1="40.64" x2="45.72" y2="40.64" width="0.2032" layer="16"/>
 </signal>
 <signal name="CS5">
 <contactref element="U$1" pad="P$25"/>
@@ -1686,9 +1686,9 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="48.26" y="68.58" extent="1-16" drill="0.45"/>
 <wire x1="48.26" y1="68.58" x2="35.69" y2="68.58" width="0.2032" layer="16"/>
 <wire x1="35.69" y1="68.58" x2="27.94" y2="76.33" width="0.2032" layer="16"/>
-<wire x1="79.6036" y1="45.72" x2="62.23" y2="45.72" width="0.2032" layer="1"/>
-<wire x1="60.96" y1="46.99" x2="60.96" y2="68.58" width="0.2032" layer="1"/>
-<wire x1="62.23" y1="45.72" x2="60.96" y2="46.99" width="0.2032" layer="1"/>
+<wire x1="79.6036" y1="48.26" x2="62.23" y2="48.26" width="0.2032" layer="1"/>
+<wire x1="60.96" y1="49.53" x2="60.96" y2="68.58" width="0.2032" layer="1"/>
+<wire x1="62.23" y1="48.26" x2="60.96" y2="49.53" width="0.2032" layer="1"/>
 <wire x1="48.26" y1="68.58" x2="60.96" y2="68.58" width="0.2032" layer="16"/>
 <via x="60.96" y="68.58" extent="1-16" drill="0.45"/>
 </signal>
@@ -1982,19 +1982,19 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <signal name="GPIO22">
 <contactref element="J1" pad="J2_5"/>
 <contactref element="U$1" pad="P$57"/>
-<contactref element="J6" pad="7"/>
 <wire x1="53.34" y1="3.81" x2="55.245" y2="1.905" width="0.2032" layer="16"/>
 <wire x1="74.295" y1="1.905" x2="55.245" y2="1.905" width="0.2032" layer="16"/>
 <wire x1="49.11170625" y1="76.33" x2="48.26" y2="76.33" width="0.2032" layer="16"/>
 <wire x1="49.11170625" y1="76.33" x2="54.32170625" y2="71.12" width="0.2032" layer="16"/>
 <wire x1="79.375" y1="71.12" x2="80.645" y2="72.39" width="0.2032" layer="16"/>
-<wire x1="86.995" y1="40.64" x2="86.995" y2="14.605" width="0.2032" layer="16"/>
+<wire x1="86.995" y1="43.18" x2="86.995" y2="14.605" width="0.2032" layer="16"/>
 <wire x1="54.32170625" y1="71.12" x2="79.375" y2="71.12" width="0.2032" layer="16"/>
 <wire x1="86.995" y1="14.605" x2="74.295" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="83.82" y1="40.64" x2="86.995" y2="40.64" width="0.2032" layer="16"/>
 <wire x1="80.645" y1="72.39" x2="85.09" y2="72.39" width="0.2032" layer="16"/>
 <wire x1="85.09" y1="72.39" x2="86.995" y2="70.485" width="0.2032" layer="16"/>
-<wire x1="86.995" y1="70.485" x2="86.995" y2="40.64" width="0.2032" layer="16"/>
+<wire x1="86.995" y1="70.485" x2="86.995" y2="43.18" width="0.2032" layer="16"/>
+<contactref element="J6" pad="8"/>
+<wire x1="83.82" y1="43.18" x2="86.995" y2="43.18" width="0.2032" layer="16"/>
 </signal>
 <signal name="GPIO23">
 <contactref element="J1" pad="J2_7"/>
@@ -2003,16 +2003,16 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="48.26" y1="3.81" x2="50.8" y2="1.27" width="0.2032" layer="1"/>
 <wire x1="50.8" y1="1.27" x2="73.025" y2="1.27" width="0.2032" layer="1"/>
 <wire x1="73.025" y1="1.27" x2="78.105" y2="6.35" width="0.2032" layer="1"/>
-<wire x1="79.6036" y1="43.18" x2="78.105" y2="43.18" width="0.2032" layer="1"/>
-<wire x1="78.105" y1="43.18" x2="60.325" y2="43.18" width="0.2032" layer="1"/>
-<wire x1="60.325" y1="43.18" x2="58.42" y2="45.085" width="0.2032" layer="1"/>
-<wire x1="58.42" y1="45.085" x2="58.42" y2="73.66" width="0.2032" layer="1"/>
+<wire x1="79.6036" y1="45.72" x2="78.105" y2="45.72" width="0.2032" layer="1"/>
+<wire x1="78.105" y1="45.72" x2="60.325" y2="45.72" width="0.2032" layer="1"/>
+<wire x1="60.325" y1="45.72" x2="58.42" y2="47.625" width="0.2032" layer="1"/>
+<wire x1="58.42" y1="47.625" x2="58.42" y2="73.66" width="0.2032" layer="1"/>
 <wire x1="58.42" y1="73.66" x2="57.15" y2="74.93" width="0.2032" layer="1"/>
 <wire x1="56.45069375" y1="80.14" x2="52.07" y2="80.14" width="0.2032" layer="1"/>
 <wire x1="52.07" y1="80.14" x2="50.8" y2="78.87" width="0.2032" layer="1"/>
 <wire x1="56.45069375" y1="80.14" x2="57.15" y2="79.44069375" width="0.2032" layer="1"/>
 <wire x1="57.15" y1="79.44069375" x2="57.15" y2="74.93" width="0.2032" layer="1"/>
-<wire x1="78.105" y1="6.35" x2="78.105" y2="43.18" width="0.2032" layer="1"/>
+<wire x1="78.105" y1="6.35" x2="78.105" y2="45.72" width="0.2032" layer="1"/>
 </signal>
 <signal name="VIN">
 <contactref element="U$1" pad="P$81"/>
@@ -2064,25 +2064,13 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 </signal>
 <signal name="LCD_BL">
 <contactref element="JP1" pad="2"/>
-<contactref element="J6" pad="9"/>
-<wire x1="80.4164" y1="45.72" x2="83.82" y2="45.72" width="0.2032" layer="1"/>
+<contactref element="J6" pad="10"/>
+<wire x1="80.4164" y1="48.26" x2="83.82" y2="48.26" width="0.2032" layer="1"/>
 </signal>
 <signal name="LCD_RST">
 <contactref element="JP2" pad="2"/>
-<contactref element="J6" pad="8"/>
-<wire x1="80.4164" y1="43.18" x2="83.82" y2="43.18" width="0.2032" layer="1"/>
-</signal>
-<signal name="Y+">
-<contactref element="J6" pad="10"/>
-</signal>
-<signal name="X+">
-<contactref element="J6" pad="11"/>
-</signal>
-<signal name="Y-">
-<contactref element="J6" pad="12"/>
-</signal>
-<signal name="X-">
-<contactref element="J6" pad="13"/>
+<contactref element="J6" pad="9"/>
+<wire x1="83.82" y1="45.72" x2="80.4164" y2="45.72" width="0.2032" layer="1"/>
 </signal>
 <signal name="BD">
 <contactref element="D3" pad="A"/>
@@ -2092,6 +2080,18 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="67.57" y1="36.065" x2="68.97" y2="37.465" width="0.4064" layer="1"/>
 <wire x1="67.57" y1="32.76" x2="63.59" y2="32.76" width="0.4064" layer="1"/>
 <wire x1="63.59" y1="32.76" x2="63.5" y2="32.85" width="0.4064" layer="1"/>
+</signal>
+<signal name="Y+">
+<contactref element="J6" pad="11"/>
+</signal>
+<signal name="X+">
+<contactref element="J6" pad="12"/>
+</signal>
+<signal name="Y-">
+<contactref element="J6" pad="13"/>
+</signal>
+<signal name="X-">
+<contactref element="J6" pad="14"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/electrical/apollo-ctrl-v4/ctrl-pico.brd
+++ b/electrical/apollo-ctrl-v4/ctrl-pico.brd
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="50" unitdist="mil" unit="mil" style="lines" multiple="1" display="no" altdistance="5" altunitdist="mil" altunit="mil"/>
+<grid distance="50" unitdist="mil" unit="mil" style="lines" multiple="1" display="no" altdistance="25" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="yes"/>
@@ -193,7 +193,7 @@
 <wire x1="88.57" y1="88.89" x2="0" y2="88.89" width="0" layer="20"/>
 <wire x1="0" y1="88.89" x2="0" y2="0" width="0" layer="20"/>
 <text x="31.115" y="25.4" size="1.778" layer="21">JLCJLCJLCJLC</text>
-<text x="3.81" y="35.56" size="1.778" layer="21" rot="R90">APOLLO CONTROL REV A</text>
+<text x="3.81" y="35.56" size="1.778" layer="21" rot="R90">APOLLO CONTROL REV B</text>
 <wire x1="5.08" y1="24.13" x2="5.08" y2="74.93" width="0.1524" layer="51"/>
 <wire x1="5.08" y1="74.93" x2="86.36" y2="74.93" width="0.1524" layer="51"/>
 <wire x1="86.36" y1="74.93" x2="86.36" y2="24.13" width="0.1524" layer="51"/>
@@ -1213,9 +1213,9 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <attribute name="NAME" x="18.542" y="6.1595" size="0.6096" layer="25" ratio="12" rot="R180"/>
 <attribute name="VALUE" x="18.796" y="8.382" size="0.6096" layer="27" ratio="12" rot="R180"/>
 </element>
-<element name="R10" library="apollo-ctrl-v4" package="0805" value="10K" x="48.26" y="17.78" smashed="yes" rot="R270">
-<attribute name="NAME" x="47.498" y="19.2405" size="0.6096" layer="25" ratio="12"/>
-<attribute name="VALUE" x="46.863" y="18.796" size="0.6096" layer="27" ratio="12" rot="R270"/>
+<element name="R10" library="apollo-ctrl-v4" package="0805" value="10K" x="48.26" y="16.002" smashed="yes" rot="R90">
+<attribute name="NAME" x="49.022" y="14.5415" size="0.6096" layer="25" ratio="12" rot="R180"/>
+<attribute name="VALUE" x="49.657" y="14.986" size="0.6096" layer="27" ratio="12" rot="R90"/>
 </element>
 <element name="R11" library="apollo-ctrl-v4" package="0805" value="10K" x="43.18" y="17.78" smashed="yes" rot="R270">
 <attribute name="NAME" x="42.418" y="19.2405" size="0.6096" layer="25" ratio="12"/>
@@ -1454,14 +1454,14 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="52.07" y="39.37" extent="1-16" drill="0.45"/>
 <via x="52.07" y="43.815" extent="1-16" drill="0.45"/>
 <via x="52.07" y="48.895" extent="1-16" drill="0.45"/>
-<via x="52.07" y="53.975" extent="1-16" drill="0.45"/>
-<via x="52.07" y="59.055" extent="1-16" drill="0.45"/>
+<via x="52.07" y="54.61" extent="1-16" drill="0.45"/>
+<via x="52.07" y="59.69" extent="1-16" drill="0.45"/>
 <via x="52.07" y="64.135" extent="1-16" drill="0.45"/>
 <via x="52.07" y="69.85" extent="1-16" drill="0.45"/>
 <via x="54.61" y="69.85" extent="1-16" drill="0.45"/>
 <via x="54.61" y="64.135" extent="1-16" drill="0.45"/>
-<via x="54.61" y="59.055" extent="1-16" drill="0.45"/>
-<via x="54.61" y="53.975" extent="1-16" drill="0.45"/>
+<via x="54.61" y="59.69" extent="1-16" drill="0.45"/>
+<via x="54.61" y="54.61" extent="1-16" drill="0.45"/>
 <via x="54.61" y="48.895" extent="1-16" drill="0.45"/>
 <via x="54.61" y="43.815" extent="1-16" drill="0.45"/>
 <via x="54.61" y="39.37" extent="1-16" drill="0.45"/>
@@ -1469,7 +1469,7 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="54.61" y="28.575" extent="1-16" drill="0.45"/>
 <via x="26.67" y="1.905" extent="1-16" drill="0.45"/>
 <via x="10.795" y="2.54" extent="1-16" drill="0.45"/>
-<via x="46.99" y="1.905" extent="1-16" drill="0.45"/>
+<via x="45.72" y="5.715" extent="1-16" drill="0.45"/>
 <wire x1="27.94" y1="78.87" x2="29.21" y2="77.6" width="0.2032" layer="1"/>
 <wire x1="29.21" y1="77.6" x2="29.21" y2="75.565" width="0.2032" layer="1"/>
 <wire x1="32.47470625" y1="77.6" x2="31.75" y2="76.87529375" width="0.2032" layer="1"/>
@@ -1481,7 +1481,7 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="55.88" y="74.295" extent="1-16" drill="0.45"/>
 <via x="58.42" y="43.815" extent="1-16" drill="0.45"/>
 <via x="59.69" y="64.135" extent="1-16" drill="0.45"/>
-<via x="76.835" y="49.53" extent="1-16" drill="0.45"/>
+<via x="76.835" y="52.07" extent="1-16" drill="0.45"/>
 <via x="21.59" y="26.67" extent="1-16" drill="0.45"/>
 <via x="24.13" y="26.67" extent="1-16" drill="0.45"/>
 <via x="27.305" y="23.495" extent="1-16" drill="0.45"/>
@@ -1490,7 +1490,7 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="12.7" y="3.81" extent="1-16" drill="0.45"/>
 <via x="2.54" y="11.43" extent="1-16" drill="0.45"/>
 <via x="5.08" y="70.485" extent="1-16" drill="0.45"/>
-<via x="36.83" y="20.32" extent="1-16" drill="0.45"/>
+<via x="38.1" y="19.05" extent="1-16" drill="0.45"/>
 <via x="34.29" y="36.83" extent="1-16" drill="0.45"/>
 <via x="36.83" y="34.29" extent="1-16" drill="0.45"/>
 <via x="36.83" y="39.37" extent="1-16" drill="0.45"/>
@@ -1504,17 +1504,24 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="76.835" y="46.99" extent="1-16" drill="0.45"/>
 <via x="41.91" y="15.875" extent="1-16" drill="0.45"/>
 <via x="44.45" y="15.875" extent="1-16" drill="0.45"/>
-<via x="55.88" y="5.715" extent="1-16" drill="0.45"/>
+<via x="54.61" y="6.985" extent="1-16" drill="0.45"/>
 <via x="78.74" y="68.58" extent="1-16" drill="0.45"/>
 <via x="55.245" y="72.39" extent="1-16" drill="0.45"/>
-<via x="73.66" y="3.81" extent="1-16" drill="0.45"/>
-<via x="27.94" y="10.16" extent="1-16" drill="0.45"/>
+<via x="72.39" y="3.175" extent="1-16" drill="0.45"/>
+<via x="26.67" y="9.525" extent="1-16" drill="0.45"/>
 <via x="85.725" y="67.31" extent="1-16" drill="0.45"/>
 <via x="85.725" y="41.91" extent="1-16" drill="0.45"/>
 <contactref element="Q1" pad="2"/>
 <contactref element="R24" pad="1"/>
 <via x="65.405" y="27.305" extent="1-16" drill="0.45"/>
 <contactref element="C8" pad="-"/>
+<via x="52.07" y="31.75" extent="1-16" drill="0.45"/>
+<via x="54.61" y="31.75" extent="1-16" drill="0.45"/>
+<via x="24.13" y="9.525" extent="1-16" drill="0.45"/>
+<via x="36.83" y="59.69" extent="1-16" drill="0.45"/>
+<via x="34.29" y="59.69" extent="1-16" drill="0.45"/>
+<via x="44.45" y="59.69" extent="1-16" drill="0.45"/>
+<via x="46.99" y="59.69" extent="1-16" drill="0.45"/>
 </signal>
 <signal name="SCK">
 <contactref element="U$1" pad="P$45"/>
@@ -1559,6 +1566,7 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <contactref element="C7" pad="1"/>
 <polygon width="0.2032" layer="1" isolate="0.3048">
 <vertex x="16.51" y="80.645"/>
+<vertex x="16.51" y="77.47"/>
 <vertex x="10.795" y="77.47"/>
 <vertex x="3.81" y="70.485"/>
 <vertex x="3.81" y="19.685"/>
@@ -1664,9 +1672,6 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <signal name="CS3">
 <contactref element="U$1" pad="P$21"/>
 <contactref element="R12" pad="1"/>
-<contactref element="J1" pad="J3_8"/>
-<wire x1="45.72" y1="18.68" x2="45.72" y2="21.59" width="0.2032" layer="1"/>
-<wire x1="45.72" y1="21.59" x2="45.72" y2="40.64" width="0.2032" layer="1"/>
 <via x="45.72" y="64.77" extent="1-16" drill="0.45"/>
 <wire x1="45.72" y1="40.64" x2="45.72" y2="64.77" width="0.2032" layer="1"/>
 <wire x1="45.72" y1="64.77" x2="34.29" y2="64.77" width="0.2032" layer="16"/>
@@ -1675,22 +1680,25 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <via x="45.72" y="40.64" extent="1-16" drill="0.45"/>
 <contactref element="J6" pad="7"/>
 <wire x1="83.82" y1="40.64" x2="45.72" y2="40.64" width="0.2032" layer="16"/>
+<contactref element="J1" pad="J3_8"/>
+<wire x1="45.72" y1="18.68" x2="45.72" y2="21.59" width="0.2032" layer="1"/>
+<wire x1="45.72" y1="40.64" x2="45.72" y2="21.59" width="0.2032" layer="1"/>
 </signal>
-<signal name="CS5">
-<contactref element="U$1" pad="P$25"/>
-<contactref element="R10" pad="1"/>
-<contactref element="J1" pad="J3_7"/>
-<contactref element="JP1" pad="1"/>
-<wire x1="48.26" y1="18.68" x2="48.26" y2="21.59" width="0.2032" layer="1"/>
-<wire x1="48.26" y1="21.59" x2="48.26" y2="68.58" width="0.2032" layer="1"/>
-<via x="48.26" y="68.58" extent="1-16" drill="0.45"/>
-<wire x1="48.26" y1="68.58" x2="35.69" y2="68.58" width="0.2032" layer="16"/>
-<wire x1="35.69" y1="68.58" x2="27.94" y2="76.33" width="0.2032" layer="16"/>
-<wire x1="79.6036" y1="48.26" x2="62.23" y2="48.26" width="0.2032" layer="1"/>
-<wire x1="60.96" y1="49.53" x2="60.96" y2="68.58" width="0.2032" layer="1"/>
-<wire x1="62.23" y1="48.26" x2="60.96" y2="49.53" width="0.2032" layer="1"/>
-<wire x1="48.26" y1="68.58" x2="60.96" y2="68.58" width="0.2032" layer="16"/>
-<via x="60.96" y="68.58" extent="1-16" drill="0.45"/>
+<signal name="ADC5">
+<contactref element="J6" pad="11"/>
+<contactref element="J1" pad="J2_15"/>
+<wire x1="27.94" y1="3.81" x2="27.94" y2="8.89" width="0.2032" layer="16"/>
+<wire x1="27.94" y1="8.89" x2="29.21" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="29.21" y1="10.16" x2="35.56" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="35.56" y1="10.16" x2="39.37" y2="13.97" width="0.2032" layer="16"/>
+<wire x1="39.37" y1="13.97" x2="39.37" y2="21.59" width="0.2032" layer="16"/>
+<wire x1="39.37" y1="21.59" x2="39.37" y2="22.225" width="0.2032" layer="16"/>
+<wire x1="39.37" y1="21.59" x2="39.2842" y2="21.6758" width="0.2032" layer="16"/>
+<wire x1="39.2842" y1="21.6758" x2="39.2842" y2="22.0805125" width="0.2032" layer="16"/>
+<wire x1="31.75" y1="29.6147125" x2="31.75" y2="49.53" width="0.2032" layer="16"/>
+<wire x1="39.2842" y1="22.0805125" x2="31.75" y2="29.6147125" width="0.2032" layer="16"/>
+<wire x1="31.75" y1="49.53" x2="33.02" y2="50.8" width="0.2032" layer="16"/>
+<wire x1="33.02" y1="50.8" x2="83.82" y2="50.8" width="0.2032" layer="16"/>
 </signal>
 <signal name="CS4">
 <contactref element="U$1" pad="P$22"/>
@@ -1772,9 +1780,6 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="84.72" y1="16.51" x2="86.36" y2="18.15" width="0.3048" layer="1"/>
 <wire x1="86.36" y1="25.4" x2="83.82" y2="27.94" width="0.3048" layer="1"/>
 <wire x1="86.36" y1="18.15" x2="86.36" y2="25.4" width="0.3048" layer="1"/>
-<via x="55.245" y="18.415" extent="1-16" drill="0.45"/>
-<wire x1="50.8" y1="16.88" x2="55.245" y2="16.88" width="0.6096" layer="1"/>
-<wire x1="55.245" y1="18.415" x2="55.245" y2="16.88" width="0.6096" layer="1"/>
 <wire x1="20.32" y1="21.59" x2="20.32" y2="17.145" width="0.6096" layer="1"/>
 <wire x1="30.48" y1="16.88" x2="20.585" y2="16.88" width="0.6096" layer="1"/>
 <wire x1="20.585" y1="16.88" x2="20.32" y2="17.145" width="0.6096" layer="1"/>
@@ -1783,17 +1788,11 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="15.24" y1="6.985" x2="15.24" y2="12.065" width="0.6096" layer="1"/>
 <wire x1="30.48" y1="16.88" x2="33.02" y2="16.88" width="0.6096" layer="1"/>
 <wire x1="40.64" y1="16.88" x2="43.18" y2="16.88" width="0.6096" layer="1"/>
-<wire x1="43.18" y1="16.88" x2="45.72" y2="16.88" width="0.6096" layer="1"/>
-<wire x1="45.72" y1="16.88" x2="48.26" y2="16.88" width="0.6096" layer="1"/>
-<wire x1="48.26" y1="16.88" x2="50.8" y2="16.88" width="0.6096" layer="1"/>
 <wire x1="16.88" y1="6.985" x2="15.24" y2="6.985" width="0.2032" layer="1"/>
 <wire x1="33.02" y1="16.88" x2="34.66" y2="15.24" width="0.6096" layer="1"/>
 <wire x1="39" y1="15.24" x2="40.64" y2="16.88" width="0.6096" layer="1"/>
 <wire x1="34.66" y1="15.24" x2="39" y2="15.24" width="0.6096" layer="1"/>
-<wire x1="55.245" y1="16.88" x2="55.88" y2="16.88" width="0.6096" layer="1"/>
-<wire x1="55.88" y1="16.88" x2="56.25" y2="16.51" width="0.6096" layer="1"/>
-<wire x1="55.245" y1="18.415" x2="65.405" y2="18.415" width="0.6096" layer="16"/>
-<wire x1="65.405" y1="18.415" x2="74.93" y2="27.94" width="0.6096" layer="16"/>
+<wire x1="63.87" y1="16.88" x2="74.93" y2="27.94" width="0.6096" layer="16"/>
 <wire x1="74.93" y1="27.94" x2="76.2" y2="27.94" width="0.6096" layer="16"/>
 <contactref element="D3" pad="C"/>
 <contactref element="SG1" pad="BP"/>
@@ -1803,6 +1802,17 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="74.67" y1="32.76" x2="76.2" y2="31.23" width="0.3048" layer="1"/>
 <wire x1="76.2" y1="31.23" x2="76.2" y2="27.94" width="0.3048" layer="1"/>
 <via x="76.2" y="27.94" extent="1-16" drill="0.35"/>
+<wire x1="48.282" y1="16.88" x2="48.26" y2="16.902" width="0.6096" layer="1"/>
+<wire x1="43.202" y1="16.902" x2="43.18" y2="16.88" width="0.6096" layer="1"/>
+<wire x1="43.18" y1="16.88" x2="45.72" y2="16.88" width="0.6096" layer="1"/>
+<wire x1="45.72" y1="16.88" x2="48.282" y2="16.88" width="0.6096" layer="1"/>
+<wire x1="48.26" y1="16.902" x2="50.778" y2="16.902" width="0.6096" layer="1"/>
+<wire x1="50.778" y1="16.902" x2="50.8" y2="16.88" width="0.6096" layer="1"/>
+<via x="55.245" y="16.88" extent="1-16" drill="0.45"/>
+<wire x1="55.245" y1="16.88" x2="63.87" y2="16.88" width="0.6096" layer="16"/>
+<wire x1="50.8" y1="16.88" x2="55.245" y2="16.88" width="0.6096" layer="1"/>
+<wire x1="55.245" y1="16.88" x2="55.88" y2="16.88" width="0.6096" layer="1"/>
+<wire x1="55.88" y1="16.88" x2="56.25" y2="16.51" width="0.6096" layer="1"/>
 </signal>
 <signal name="A2">
 <contactref element="R2" pad="2"/>
@@ -1856,16 +1866,15 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="20.32" y1="44.45" x2="21.59" y2="43.18" width="0.2032" layer="16"/>
 <wire x1="21.59" y1="43.18" x2="24.765" y2="43.18" width="0.2032" layer="16"/>
 <wire x1="24.765" y1="43.18" x2="26.67" y2="41.275" width="0.2032" layer="16"/>
-<via x="33.655" y="13.97" extent="1-16" drill="0.45"/>
-<wire x1="33.655" y1="13.97" x2="42.28" y2="13.97" width="0.2032" layer="1"/>
+<via x="32.385" y="13.97" extent="1-16" drill="0.45"/>
+<wire x1="32.385" y1="13.97" x2="42.28" y2="13.97" width="0.2032" layer="1"/>
 <wire x1="42.28" y1="13.97" x2="43.18" y2="13.07" width="0.2032" layer="1"/>
 <wire x1="26.67" y1="41.275" x2="26.67" y2="27.46398125" width="0.2032" layer="16"/>
-<wire x1="31.7483" y1="15.8767" x2="31.7483" y2="22.38568125" width="0.2032" layer="16"/>
-<wire x1="33.655" y1="13.97" x2="31.7483" y2="15.8767" width="0.2032" layer="16"/>
+<wire x1="31.7483" y1="14.6067" x2="31.7483" y2="22.38568125" width="0.2032" layer="16"/>
+<wire x1="32.385" y1="13.97" x2="31.7483" y2="14.6067" width="0.2032" layer="16"/>
 <wire x1="31.7483" y1="22.38568125" x2="26.67" y2="27.46398125" width="0.2032" layer="16"/>
 </signal>
 <signal name="VMON">
-<contactref element="J1" pad="J2_15"/>
 <contactref element="R19" pad="2"/>
 <contactref element="R18" pad="1"/>
 <wire x1="79.11" y1="73.025" x2="77.735" y2="73.025" width="0.2032" layer="1"/>
@@ -1874,80 +1883,48 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="81.28" y1="69.85" x2="86.36" y2="69.85" width="0.2032" layer="1"/>
 <wire x1="86.36" y1="69.85" x2="87.63" y2="68.58" width="0.2032" layer="1"/>
 <wire x1="87.63" y1="68.58" x2="87.63" y2="11.43" width="0.2032" layer="1"/>
-<wire x1="87.63" y1="11.43" x2="85.9409" y2="9.7409" width="0.2032" layer="1"/>
-<via x="79.375" y="9.7282" extent="1-16" drill="0.45"/>
-<wire x1="79.375" y1="9.7282" x2="79.3623" y2="9.7409" width="0.2032" layer="16"/>
-<wire x1="79.3623" y1="9.7409" x2="30.0609" y2="9.7409" width="0.2032" layer="16"/>
-<wire x1="30.0609" y1="9.7409" x2="27.94" y2="7.62" width="0.2032" layer="16"/>
-<wire x1="27.94" y1="7.62" x2="27.94" y2="3.81" width="0.2032" layer="16"/>
-<wire x1="85.9409" y1="9.7409" x2="79.3877" y2="9.7409" width="0.2032" layer="1"/>
-<wire x1="79.3877" y1="9.7409" x2="79.375" y2="9.7282" width="0.2032" layer="1"/>
+<contactref element="J1" pad="J2_14"/>
+<wire x1="77.47" y1="1.905" x2="32.385" y2="1.905" width="0.2032" layer="16"/>
+<wire x1="32.385" y1="1.905" x2="30.48" y2="3.81" width="0.2032" layer="16"/>
+<wire x1="85.725" y1="9.525" x2="80.645" y2="9.525" width="0.2032" layer="1"/>
+<wire x1="80.645" y1="9.525" x2="79.375" y2="8.255" width="0.2032" layer="1"/>
+<wire x1="79.375" y1="8.255" x2="79.375" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="79.375" y1="3.81" x2="77.47" y2="1.905" width="0.2032" layer="1"/>
+<via x="77.47" y="1.905" extent="1-16" drill="0.45"/>
+<wire x1="87.63" y1="11.43" x2="85.725" y2="9.525" width="0.2032" layer="1"/>
 </signal>
 <signal name="ADC2">
-<contactref element="J1" pad="J2_14"/>
-<contactref element="Q1" pad="1"/>
-<contactref element="R24" pad="2"/>
-<wire x1="62.55" y1="30.75" x2="62.55" y2="28.625" width="0.2032" layer="1"/>
-<wire x1="62.55" y1="28.625" x2="62.6" y2="28.575" width="0.2032" layer="1"/>
-<wire x1="30.48" y1="3.81" x2="30.48" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="30.48" y1="1.905" x2="31.115" y2="1.27" width="0.2032" layer="16"/>
-<wire x1="31.115" y1="1.27" x2="51.435" y2="1.27" width="0.2032" layer="16"/>
-<wire x1="51.435" y1="1.27" x2="52.07" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="52.07" y1="1.905" x2="52.07" y2="5.715" width="0.2032" layer="16"/>
-<wire x1="53.34" y1="6.985" x2="61.595" y2="6.985" width="0.2032" layer="16"/>
-<via x="61.595" y="6.985" extent="1-16" drill="0.35"/>
-<wire x1="61.595" y1="6.985" x2="68.58" y2="6.985" width="0.2032" layer="1"/>
-<wire x1="68.58" y1="6.985" x2="69.85" y2="8.255" width="0.2032" layer="1"/>
-<wire x1="69.85" y1="8.255" x2="69.85" y2="19.685" width="0.2032" layer="1"/>
-<wire x1="69.85" y1="19.685" x2="63.1825" y2="26.3525" width="0.2032" layer="1"/>
-<wire x1="63.1825" y1="26.3525" x2="62.865" y2="26.67" width="0.2032" layer="1"/>
-<wire x1="52.07" y1="5.715" x2="53.34" y2="6.985" width="0.2032" layer="16"/>
-<wire x1="62.6" y1="28.575" x2="62.6" y2="26.935" width="0.2032" layer="1"/>
-<wire x1="62.6" y1="26.935" x2="62.865" y2="26.67" width="0.2032" layer="1"/>
+<contactref element="J1" pad="J3_7"/>
+<wire x1="48.26" y1="21.59" x2="48.26" y2="53.34" width="0.2032" layer="1"/>
+<via x="48.26" y="53.34" extent="1-16" drill="0.45"/>
+<contactref element="J6" pad="12"/>
+<wire x1="48.26" y1="53.34" x2="83.82" y2="53.34" width="0.2032" layer="16"/>
 </signal>
 <signal name="ADC3">
 <contactref element="J1" pad="J2_17"/>
-<contactref element="U$1" pad="P$30"/>
-<wire x1="22.86" y1="3.81" x2="20.955" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="20.955" y1="1.905" x2="12.7" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="12.7" y1="1.905" x2="11.43" y2="3.175" width="0.2032" layer="16"/>
-<wire x1="11.43" y1="3.175" x2="11.43" y2="8.255" width="0.2032" layer="16"/>
-<wire x1="11.43" y1="8.255" x2="8.255" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="8.255" y1="11.43" x2="4.445" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="29.21" y1="80.14" x2="30.48" y2="78.87" width="0.2032" layer="16"/>
-<wire x1="14.00729375" y1="80.14" x2="29.21" y2="80.14" width="0.2032" layer="16"/>
-<wire x1="14.00729375" y1="80.14" x2="13.75329375" y2="80.394" width="0.2032" layer="16"/>
-<wire x1="13.75329375" y1="80.394" x2="11.5062" y2="80.394" width="0.2032" layer="16"/>
-<wire x1="3.81" y1="12.065" x2="4.445" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="11.5062" y1="80.394" x2="10.795" y2="79.6828" width="0.2032" layer="16"/>
-<wire x1="10.795" y1="73.66" x2="9.525" y2="72.39" width="0.2032" layer="16"/>
-<wire x1="9.525" y1="72.39" x2="5.08" y2="72.39" width="0.2032" layer="16"/>
-<wire x1="5.08" y1="72.39" x2="3.81" y2="71.12" width="0.2032" layer="16"/>
-<wire x1="3.81" y1="71.12" x2="3.81" y2="12.065" width="0.2032" layer="16"/>
-<wire x1="10.795" y1="79.6828" x2="10.795" y2="73.66" width="0.2032" layer="16"/>
+<contactref element="J6" pad="14"/>
+<wire x1="22.86" y1="3.81" x2="22.86" y2="11.43" width="0.2032" layer="16"/>
+<wire x1="22.86" y1="11.43" x2="24.13" y2="12.7" width="0.2032" layer="16"/>
+<wire x1="28.16201875" y1="28.7659625" x2="28.16201875" y2="52.92701875" width="0.2032" layer="16"/>
+<wire x1="28.16201875" y1="52.92701875" x2="33.655" y2="58.42" width="0.2032" layer="16"/>
+<wire x1="33.655" y1="58.42" x2="83.82" y2="58.42" width="0.2032" layer="16"/>
+<wire x1="33.655" y1="12.7" x2="24.13" y2="12.7" width="0.2032" layer="16"/>
+<wire x1="34.2042" y1="13.2492" x2="34.2042" y2="22.72378125" width="0.2032" layer="16"/>
+<wire x1="34.2042" y1="22.72378125" x2="28.16201875" y2="28.7659625" width="0.2032" layer="16"/>
+<wire x1="34.2042" y1="13.2492" x2="33.655" y2="12.7" width="0.2032" layer="16"/>
 </signal>
 <signal name="ADC4">
 <contactref element="J1" pad="J2_16"/>
-<contactref element="U$1" pad="P$34"/>
-<wire x1="25.4" y1="3.81" x2="22.86" y2="1.27" width="0.2032" layer="16"/>
-<wire x1="22.86" y1="1.27" x2="10.795" y2="1.27" width="0.2032" layer="16"/>
-<wire x1="10.795" y1="1.27" x2="9.525" y2="2.54" width="0.2032" layer="16"/>
-<wire x1="9.525" y1="2.54" x2="9.525" y2="7.62" width="0.2032" layer="16"/>
-<wire x1="9.525" y1="7.62" x2="7.62" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="7.62" y1="9.525" x2="3.175" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="31.75" y1="82.13309375" x2="31.20309375" y2="82.68" width="0.2032" layer="16"/>
-<wire x1="31.75" y1="80.14" x2="31.75" y2="82.13309375" width="0.2032" layer="16"/>
-<wire x1="33.02" y1="78.87" x2="31.75" y2="80.14" width="0.2032" layer="16"/>
-<wire x1="14.00729375" y1="82.68" x2="13.75329375" y2="82.934" width="0.2032" layer="16"/>
-<wire x1="13.75329375" y1="82.934" x2="10.544" y2="82.934" width="0.2032" layer="16"/>
-<wire x1="31.20309375" y1="82.68" x2="14.00729375" y2="82.68" width="0.2032" layer="16"/>
-<wire x1="1.27" y1="11.43" x2="3.175" y2="9.525" width="0.2032" layer="16"/>
-<wire x1="9.6266" y1="82.0166" x2="10.544" y2="82.934" width="0.2032" layer="16"/>
-<wire x1="8.255" y1="75.565" x2="4.445" y2="75.565" width="0.2032" layer="16"/>
-<wire x1="4.445" y1="75.565" x2="1.27" y2="72.39" width="0.2032" layer="16"/>
-<wire x1="1.27" y1="72.39" x2="1.27" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="8.255" y1="75.565" x2="9.6266" y2="76.9366" width="0.2032" layer="16"/>
-<wire x1="9.6266" y1="76.9366" x2="9.6266" y2="82.0166" width="0.2032" layer="16"/>
+<contactref element="J6" pad="13"/>
+<wire x1="25.4" y1="3.81" x2="25.4" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="25.4" y1="10.16" x2="26.67" y2="11.43" width="0.2032" layer="16"/>
+<wire x1="26.67" y1="11.43" x2="34.29" y2="11.43" width="0.2032" layer="16"/>
+<wire x1="34.29" y1="11.43" x2="36.83" y2="13.97" width="0.2032" layer="16"/>
+<wire x1="29.845" y1="52.705" x2="33.02" y2="55.88" width="0.2032" layer="16"/>
+<wire x1="33.02" y1="55.88" x2="83.82" y2="55.88" width="0.2032" layer="16"/>
+<wire x1="36.83" y1="13.97" x2="36.83" y2="22.63798125" width="0.2032" layer="16"/>
+<wire x1="36.83" y1="22.63798125" x2="29.845" y2="29.62298125" width="0.2032" layer="16"/>
+<wire x1="29.845" y1="29.62298125" x2="29.845" y2="52.705" width="0.2032" layer="16"/>
 </signal>
 <signal name="ADCDP">
 <contactref element="J1" pad="J3_4"/>
@@ -1982,19 +1959,28 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <signal name="GPIO22">
 <contactref element="J1" pad="J2_5"/>
 <contactref element="U$1" pad="P$57"/>
-<wire x1="53.34" y1="3.81" x2="55.245" y2="1.905" width="0.2032" layer="16"/>
-<wire x1="74.295" y1="1.905" x2="55.245" y2="1.905" width="0.2032" layer="16"/>
+<wire x1="53.34" y1="3.81" x2="55.245" y2="5.715" width="0.2032" layer="16"/>
 <wire x1="49.11170625" y1="76.33" x2="48.26" y2="76.33" width="0.2032" layer="16"/>
 <wire x1="49.11170625" y1="76.33" x2="54.32170625" y2="71.12" width="0.2032" layer="16"/>
 <wire x1="79.375" y1="71.12" x2="80.645" y2="72.39" width="0.2032" layer="16"/>
-<wire x1="86.995" y1="43.18" x2="86.995" y2="14.605" width="0.2032" layer="16"/>
 <wire x1="54.32170625" y1="71.12" x2="79.375" y2="71.12" width="0.2032" layer="16"/>
-<wire x1="86.995" y1="14.605" x2="74.295" y2="1.905" width="0.2032" layer="16"/>
 <wire x1="80.645" y1="72.39" x2="85.09" y2="72.39" width="0.2032" layer="16"/>
 <wire x1="85.09" y1="72.39" x2="86.995" y2="70.485" width="0.2032" layer="16"/>
-<wire x1="86.995" y1="70.485" x2="86.995" y2="43.18" width="0.2032" layer="16"/>
-<contactref element="J6" pad="8"/>
-<wire x1="83.82" y1="43.18" x2="86.995" y2="43.18" width="0.2032" layer="16"/>
+<wire x1="86.995" y1="70.485" x2="86.995" y2="49.53" width="0.2032" layer="16"/>
+<contactref element="JP1" pad="1"/>
+<wire x1="86.995" y1="49.53" x2="78.74" y2="49.53" width="0.2032" layer="16"/>
+<wire x1="78.74" y1="49.53" x2="77.47" y2="48.26" width="0.2032" layer="16"/>
+<via x="77.47" y="48.26" extent="1-16" drill="0.45"/>
+<wire x1="77.47" y1="48.26" x2="79.6036" y2="48.26" width="0.2032" layer="1"/>
+<wire x1="55.245" y1="5.715" x2="65.405" y2="5.715" width="0.2032" layer="16"/>
+<wire x1="65.405" y1="5.715" x2="66.04" y2="5.08" width="0.2032" layer="16"/>
+<wire x1="66.04" y1="5.08" x2="78.105" y2="5.08" width="0.2032" layer="16"/>
+<wire x1="78.105" y1="5.08" x2="78.74" y2="5.715" width="0.2032" layer="16"/>
+<wire x1="78.74" y1="5.715" x2="78.74" y2="8.89" width="0.2032" layer="16"/>
+<wire x1="78.74" y1="8.89" x2="80.01" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="80.01" y1="10.16" x2="85.09" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="85.09" y1="10.16" x2="86.995" y2="12.065" width="0.2032" layer="16"/>
+<wire x1="86.995" y1="12.065" x2="86.995" y2="49.53" width="0.2032" layer="16"/>
 </signal>
 <signal name="GPIO23">
 <contactref element="J1" pad="J2_7"/>
@@ -2035,11 +2021,22 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <vertex x="67.31" y="80.01"/>
 </polygon>
 </signal>
-<signal name="SDA2">
+<signal name="LCD_CD">
+<contactref element="J6" pad="8"/>
+<contactref element="R10" pad="1"/>
 <contactref element="J1" pad="J2_8"/>
-</signal>
-<signal name="SCL2">
-<contactref element="J1" pad="J2_6"/>
+<wire x1="48.26" y1="15.102" x2="48.26" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="48.26" y1="13.335" x2="48.26" y2="6.35" width="0.2032" layer="1"/>
+<wire x1="48.26" y1="6.35" x2="45.72" y2="3.81" width="0.2032" layer="1"/>
+<wire x1="83.82" y1="43.18" x2="59.69" y2="43.18" width="0.2032" layer="16"/>
+<via x="59.69" y="43.18" extent="1-16" drill="0.45"/>
+<wire x1="59.69" y1="43.18" x2="59.69" y2="20.32" width="0.2032" layer="1"/>
+<via x="59.69" y="20.32" extent="1-16" drill="0.45"/>
+<wire x1="59.69" y1="20.32" x2="59.055" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="59.055" y1="19.685" x2="51.435" y2="19.685" width="0.2032" layer="16"/>
+<wire x1="51.435" y1="19.685" x2="48.26" y2="16.51" width="0.2032" layer="16"/>
+<via x="48.26" y="13.335" extent="1-16" drill="0.45"/>
+<wire x1="48.26" y1="16.51" x2="48.26" y2="13.335" width="0.2032" layer="16"/>
 </signal>
 <signal name="VLED">
 <contactref element="R22" pad="2"/>
@@ -2081,17 +2078,21 @@ Note, that not all DRC settings must be set by the manufacturer. Several can be 
 <wire x1="67.57" y1="32.76" x2="63.59" y2="32.76" width="0.4064" layer="1"/>
 <wire x1="63.59" y1="32.76" x2="63.5" y2="32.85" width="0.4064" layer="1"/>
 </signal>
-<signal name="Y+">
-<contactref element="J6" pad="11"/>
-</signal>
-<signal name="X+">
-<contactref element="J6" pad="12"/>
-</signal>
-<signal name="Y-">
-<contactref element="J6" pad="13"/>
-</signal>
-<signal name="X-">
-<contactref element="J6" pad="14"/>
+<signal name="BUZ">
+<contactref element="Q1" pad="1"/>
+<contactref element="R24" pad="2"/>
+<wire x1="62.55" y1="30.75" x2="62.55" y2="28.625" width="0.2032" layer="1"/>
+<wire x1="62.55" y1="28.625" x2="62.6" y2="28.575" width="0.2032" layer="1"/>
+<contactref element="J1" pad="J2_6"/>
+<wire x1="50.8" y1="3.81" x2="50.8" y2="16.51" width="0.2032" layer="16"/>
+<wire x1="50.8" y1="16.51" x2="52.705" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="52.705" y1="18.415" x2="60.325" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="60.325" y1="18.415" x2="62.2046" y2="20.2946" width="0.2032" layer="16"/>
+<wire x1="62.2046" y1="26.6446" x2="62.23" y2="26.67" width="0.2032" layer="16"/>
+<wire x1="62.2046" y1="26.6446" x2="62.2046" y2="20.2946" width="0.2032" layer="16"/>
+<via x="62.23" y="26.67" extent="1-16" drill="0.45"/>
+<wire x1="62.6" y1="28.575" x2="62.6" y2="27.04" width="0.2032" layer="1"/>
+<wire x1="62.6" y1="27.04" x2="62.23" y2="26.67" width="0.2032" layer="1"/>
 </signal>
 </signals>
 <mfgpreviewcolors>

--- a/electrical/apollo-ctrl-v4/ctrl-pico.sch
+++ b/electrical/apollo-ctrl-v4/ctrl-pico.sch
@@ -3,7 +3,7 @@
 <eagle version="9.6.2">
 <drawing>
 <settings>
-<setting alwaysvectorfont="no"/>
+<setting alwaysvectorfont="yes"/>
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
@@ -6738,9 +6738,9 @@ Multiplier is ~0.0434</text>
 <label x="20.32" y="71.12" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="3"/>
-<wire x1="314.96" y1="134.62" x2="320.04" y2="134.62" width="0.1524" layer="91"/>
-<label x="320.04" y="134.62" size="1.778" layer="95"/>
+<wire x1="314.96" y1="137.16" x2="320.04" y2="137.16" width="0.1524" layer="91"/>
+<label x="320.04" y="137.16" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="4"/>
 </segment>
 </net>
 <net name="CODI" class="0">
@@ -6757,9 +6757,9 @@ Multiplier is ~0.0434</text>
 <label x="20.32" y="76.2" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="5"/>
-<wire x1="320.04" y1="139.7" x2="314.96" y2="139.7" width="0.1524" layer="91"/>
-<label x="320.04" y="139.7" size="1.778" layer="95"/>
+<wire x1="320.04" y1="142.24" x2="314.96" y2="142.24" width="0.1524" layer="91"/>
+<label x="320.04" y="142.24" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="6"/>
 </segment>
 </net>
 <net name="!LOE!" class="0">
@@ -6899,9 +6899,9 @@ Multiplier is ~0.0434</text>
 <label x="48.26" y="162.56" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="4"/>
-<wire x1="314.96" y1="137.16" x2="320.04" y2="137.16" width="0.1524" layer="91"/>
-<label x="320.04" y="137.16" size="1.778" layer="95"/>
+<wire x1="314.96" y1="139.7" x2="320.04" y2="139.7" width="0.1524" layer="91"/>
+<label x="320.04" y="139.7" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="5"/>
 </segment>
 </net>
 <net name="CS1" class="0">
@@ -6958,9 +6958,9 @@ Multiplier is ~0.0434</text>
 <label x="20.32" y="45.72" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="6"/>
-<wire x1="320.04" y1="142.24" x2="314.96" y2="142.24" width="0.1524" layer="91"/>
-<label x="320.04" y="142.24" size="1.778" layer="95"/>
+<wire x1="320.04" y1="144.78" x2="314.96" y2="144.78" width="0.1524" layer="91"/>
+<label x="320.04" y="144.78" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="7"/>
 </segment>
 </net>
 <net name="CS5" class="0">
@@ -7311,9 +7311,9 @@ Multiplier is ~0.0434</text>
 <label x="93.98" y="142.24" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="7"/>
-<wire x1="320.04" y1="144.78" x2="314.96" y2="144.78" width="0.1524" layer="91"/>
-<label x="320.04" y="144.78" size="1.778" layer="95"/>
+<wire x1="320.04" y1="147.32" x2="314.96" y2="147.32" width="0.1524" layer="91"/>
+<label x="320.04" y="147.32" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="8"/>
 </segment>
 </net>
 <net name="GPIO23" class="0">
@@ -7418,9 +7418,9 @@ Multiplier is ~0.0434</text>
 <label x="274.32" y="172.72" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="9"/>
-<wire x1="320.04" y1="149.86" x2="314.96" y2="149.86" width="0.1524" layer="91"/>
-<label x="320.04" y="149.86" size="1.778" layer="95"/>
+<wire x1="320.04" y1="152.4" x2="314.96" y2="152.4" width="0.1524" layer="91"/>
+<label x="320.04" y="152.4" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="10"/>
 </segment>
 </net>
 <net name="LCD_RST" class="0">
@@ -7430,37 +7430,37 @@ Multiplier is ~0.0434</text>
 <label x="274.32" y="160.02" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J6" gate="G$1" pin="8"/>
-<wire x1="320.04" y1="147.32" x2="314.96" y2="147.32" width="0.1524" layer="91"/>
-<label x="320.04" y="147.32" size="1.778" layer="95"/>
+<wire x1="320.04" y1="149.86" x2="314.96" y2="149.86" width="0.1524" layer="91"/>
+<label x="320.04" y="149.86" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="9"/>
 </segment>
 </net>
 <net name="Y+" class="0">
 <segment>
-<pinref part="J6" gate="G$1" pin="10"/>
-<wire x1="320.04" y1="152.4" x2="314.96" y2="152.4" width="0.1524" layer="91"/>
-<label x="320.04" y="152.4" size="1.778" layer="95"/>
+<wire x1="320.04" y1="154.94" x2="314.96" y2="154.94" width="0.1524" layer="91"/>
+<label x="320.04" y="154.94" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="11"/>
 </segment>
 </net>
 <net name="X+" class="0">
 <segment>
-<pinref part="J6" gate="G$1" pin="11"/>
-<wire x1="320.04" y1="154.94" x2="314.96" y2="154.94" width="0.1524" layer="91"/>
-<label x="320.04" y="154.94" size="1.778" layer="95"/>
+<wire x1="320.04" y1="157.48" x2="314.96" y2="157.48" width="0.1524" layer="91"/>
+<label x="320.04" y="157.48" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="12"/>
 </segment>
 </net>
 <net name="Y-" class="0">
 <segment>
-<pinref part="J6" gate="G$1" pin="12"/>
-<wire x1="320.04" y1="157.48" x2="314.96" y2="157.48" width="0.1524" layer="91"/>
-<label x="320.04" y="157.48" size="1.778" layer="95"/>
+<wire x1="320.04" y1="160.02" x2="314.96" y2="160.02" width="0.1524" layer="91"/>
+<label x="320.04" y="160.02" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="13"/>
 </segment>
 </net>
 <net name="X-" class="0">
 <segment>
-<pinref part="J6" gate="G$1" pin="13"/>
-<wire x1="320.04" y1="160.02" x2="314.96" y2="160.02" width="0.1524" layer="91"/>
-<label x="320.04" y="160.02" size="1.778" layer="95"/>
+<wire x1="320.04" y1="162.56" x2="314.96" y2="162.56" width="0.1524" layer="91"/>
+<label x="320.04" y="162.56" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="14"/>
 </segment>
 </net>
 <net name="BD" class="0">

--- a/electrical/apollo-ctrl-v4/ctrl-pico.sch
+++ b/electrical/apollo-ctrl-v4/ctrl-pico.sch
@@ -6953,37 +6953,26 @@ Multiplier is ~0.0434</text>
 <label x="25.4" y="162.56" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="J1" gate="G$1" pin="IO32"/>
-<wire x1="20.32" y1="45.72" x2="33.02" y2="45.72" width="0.1524" layer="91"/>
-<label x="20.32" y="45.72" size="1.778" layer="95"/>
-</segment>
-<segment>
 <wire x1="320.04" y1="144.78" x2="314.96" y2="144.78" width="0.1524" layer="91"/>
 <label x="320.04" y="144.78" size="1.778" layer="95"/>
 <pinref part="J6" gate="G$1" pin="7"/>
 </segment>
+<segment>
+<pinref part="J1" gate="G$1" pin="IO32"/>
+<wire x1="20.32" y1="45.72" x2="33.02" y2="45.72" width="0.1524" layer="91"/>
+<label x="20.32" y="45.72" size="1.778" layer="95"/>
+</segment>
 </net>
-<net name="CS5" class="0">
+<net name="ADC5" class="0">
 <segment>
-<pinref part="U$1" gate="G$1" pin="PIN7"/>
-<wire x1="93.98" y1="162.56" x2="106.68" y2="162.56" width="0.1524" layer="91"/>
-<label x="93.98" y="162.56" size="1.778" layer="95"/>
+<label x="320.04" y="154.94" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="11"/>
+<wire x1="314.96" y1="154.94" x2="320.04" y2="154.94" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<pinref part="R10" gate="G$1" pin="1"/>
-<wire x1="12.7" y1="162.56" x2="7.62" y2="162.56" width="0.1524" layer="91"/>
-<wire x1="7.62" y1="162.56" x2="7.62" y2="165.1" width="0.1524" layer="91"/>
-<label x="10.16" y="162.56" size="1.778" layer="95"/>
-</segment>
-<segment>
-<pinref part="J1" gate="G$1" pin="IO26"/>
-<wire x1="20.32" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="91"/>
-<label x="20.32" y="50.8" size="1.778" layer="95"/>
-</segment>
-<segment>
-<pinref part="JP1" gate="G$1" pin="1"/>
-<wire x1="254" y1="172.72" x2="261.62" y2="172.72" width="0.1524" layer="91"/>
-<label x="254" y="172.72" size="1.778" layer="95"/>
+<pinref part="J1" gate="G$1" pin="IO34"/>
+<wire x1="20.32" y1="40.64" x2="33.02" y2="40.64" width="0.1524" layer="91"/>
+<label x="20.32" y="40.64" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="CS4" class="0">
@@ -7182,6 +7171,7 @@ Multiplier is ~0.0434</text>
 <wire x1="33.02" y1="78.74" x2="17.78" y2="78.74" width="0.1524" layer="91"/>
 <wire x1="17.78" y1="78.74" x2="17.78" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="R6" gate="G$1" pin="2"/>
+<label x="20.32" y="78.74" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="RX" class="0">
@@ -7190,6 +7180,7 @@ Multiplier is ~0.0434</text>
 <wire x1="33.02" y1="81.28" x2="17.78" y2="81.28" width="0.1524" layer="91"/>
 <wire x1="17.78" y1="81.28" x2="17.78" y2="83.82" width="0.1524" layer="91"/>
 <pinref part="R5" gate="G$1" pin="2"/>
+<label x="20.32" y="81.28" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="!FAULT!" class="0">
@@ -7212,11 +7203,6 @@ Multiplier is ~0.0434</text>
 </net>
 <net name="VMON" class="0">
 <segment>
-<pinref part="J1" gate="G$1" pin="IO34"/>
-<wire x1="20.32" y1="40.64" x2="33.02" y2="40.64" width="0.1524" layer="91"/>
-<label x="20.32" y="40.64" size="1.778" layer="95"/>
-</segment>
-<segment>
 <pinref part="R19" gate="G$1" pin="2"/>
 <pinref part="R18" gate="G$1" pin="1"/>
 <wire x1="134.62" y1="88.9" x2="134.62" y2="91.44" width="0.1524" layer="91"/>
@@ -7225,18 +7211,22 @@ Multiplier is ~0.0434</text>
 <junction x="134.62" y="91.44"/>
 <label x="124.46" y="91.44" size="1.778" layer="95"/>
 </segment>
-</net>
-<net name="ADC2" class="0">
 <segment>
 <pinref part="J1" gate="G$1" pin="IO35"/>
 <wire x1="20.32" y1="38.1" x2="33.02" y2="38.1" width="0.1524" layer="91"/>
 <label x="20.32" y="38.1" size="1.778" layer="95"/>
 </segment>
+</net>
+<net name="ADC2" class="0">
 <segment>
-<pinref part="Q1" gate="NMOS" pin="G"/>
-<wire x1="40.64" y1="116.84" x2="27.94" y2="116.84" width="0.1524" layer="91"/>
-<label x="30.48" y="116.84" size="1.778" layer="95"/>
-<pinref part="R24" gate="G$1" pin="2"/>
+<pinref part="J1" gate="G$1" pin="IO26"/>
+<wire x1="20.32" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="91"/>
+<label x="20.32" y="50.8" size="1.778" layer="95"/>
+</segment>
+<segment>
+<label x="320.04" y="157.48" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="12"/>
+<wire x1="314.96" y1="157.48" x2="320.04" y2="157.48" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="ADC3" class="0">
@@ -7246,9 +7236,9 @@ Multiplier is ~0.0434</text>
 <label x="20.32" y="35.56" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="U$1" gate="G$1" pin="PIN34"/>
-<wire x1="167.64" y1="160.02" x2="160.02" y2="160.02" width="0.1524" layer="91"/>
-<label x="165.1" y="160.02" size="1.778" layer="95"/>
+<label x="320.04" y="162.56" size="1.778" layer="95"/>
+<wire x1="314.96" y1="162.56" x2="320.04" y2="162.56" width="0.1524" layer="91"/>
+<pinref part="J6" gate="G$1" pin="14"/>
 </segment>
 </net>
 <net name="ADC4" class="0">
@@ -7258,9 +7248,9 @@ Multiplier is ~0.0434</text>
 <label x="20.32" y="33.02" size="1.778" layer="95"/>
 </segment>
 <segment>
-<pinref part="U$1" gate="G$1" pin="PIN35"/>
-<wire x1="167.64" y1="157.48" x2="160.02" y2="157.48" width="0.1524" layer="91"/>
-<label x="165.1" y="157.48" size="1.778" layer="95"/>
+<label x="320.04" y="160.02" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="13"/>
+<wire x1="314.96" y1="160.02" x2="320.04" y2="160.02" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="ADCDP" class="0">
@@ -7311,9 +7301,9 @@ Multiplier is ~0.0434</text>
 <label x="93.98" y="142.24" size="1.778" layer="95"/>
 </segment>
 <segment>
-<wire x1="320.04" y1="147.32" x2="314.96" y2="147.32" width="0.1524" layer="91"/>
-<label x="320.04" y="147.32" size="1.778" layer="95"/>
-<pinref part="J6" gate="G$1" pin="8"/>
+<pinref part="JP1" gate="G$1" pin="1"/>
+<wire x1="254" y1="172.72" x2="261.62" y2="172.72" width="0.1524" layer="91"/>
+<label x="254" y="172.72" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="GPIO23" class="0">
@@ -7363,18 +7353,22 @@ Multiplier is ~0.0434</text>
 <wire x1="175.26" y1="106.68" x2="134.62" y2="106.68" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="SDA2" class="0">
+<net name="LCD_CD" class="0">
+<segment>
+<wire x1="320.04" y1="147.32" x2="314.96" y2="147.32" width="0.1524" layer="91"/>
+<label x="320.04" y="147.32" size="1.778" layer="95"/>
+<pinref part="J6" gate="G$1" pin="8"/>
+</segment>
+<segment>
+<pinref part="R10" gate="G$1" pin="1"/>
+<wire x1="12.7" y1="160.02" x2="7.62" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="7.62" y1="160.02" x2="7.62" y2="165.1" width="0.1524" layer="91"/>
+<label x="10.16" y="160.02" size="1.778" layer="95"/>
+</segment>
 <segment>
 <pinref part="J1" gate="G$1" pin="IO18"/>
 <wire x1="20.32" y1="66.04" x2="33.02" y2="66.04" width="0.1524" layer="91"/>
 <label x="20.32" y="66.04" size="1.778" layer="95"/>
-</segment>
-</net>
-<net name="SCL2" class="0">
-<segment>
-<pinref part="J1" gate="G$1" pin="IO19"/>
-<wire x1="20.32" y1="63.5" x2="33.02" y2="63.5" width="0.1524" layer="91"/>
-<label x="20.32" y="63.5" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="VLED" class="0">
@@ -7435,34 +7429,6 @@ Multiplier is ~0.0434</text>
 <pinref part="J6" gate="G$1" pin="9"/>
 </segment>
 </net>
-<net name="Y+" class="0">
-<segment>
-<wire x1="320.04" y1="154.94" x2="314.96" y2="154.94" width="0.1524" layer="91"/>
-<label x="320.04" y="154.94" size="1.778" layer="95"/>
-<pinref part="J6" gate="G$1" pin="11"/>
-</segment>
-</net>
-<net name="X+" class="0">
-<segment>
-<wire x1="320.04" y1="157.48" x2="314.96" y2="157.48" width="0.1524" layer="91"/>
-<label x="320.04" y="157.48" size="1.778" layer="95"/>
-<pinref part="J6" gate="G$1" pin="12"/>
-</segment>
-</net>
-<net name="Y-" class="0">
-<segment>
-<wire x1="320.04" y1="160.02" x2="314.96" y2="160.02" width="0.1524" layer="91"/>
-<label x="320.04" y="160.02" size="1.778" layer="95"/>
-<pinref part="J6" gate="G$1" pin="13"/>
-</segment>
-</net>
-<net name="X-" class="0">
-<segment>
-<wire x1="320.04" y1="162.56" x2="314.96" y2="162.56" width="0.1524" layer="91"/>
-<label x="320.04" y="162.56" size="1.778" layer="95"/>
-<pinref part="J6" gate="G$1" pin="14"/>
-</segment>
-</net>
 <net name="BD" class="0">
 <segment>
 <wire x1="50.8" y1="132.08" x2="48.26" y2="132.08" width="0.1524" layer="91"/>
@@ -7475,6 +7441,19 @@ Multiplier is ~0.0434</text>
 <wire x1="48.26" y1="124.46" x2="48.26" y2="127" width="0.1524" layer="91"/>
 <junction x="48.26" y="127"/>
 <pinref part="SG1" gate="G$1" pin="N"/>
+</segment>
+</net>
+<net name="BUZ" class="0">
+<segment>
+<pinref part="Q1" gate="NMOS" pin="G"/>
+<wire x1="40.64" y1="116.84" x2="27.94" y2="116.84" width="0.1524" layer="91"/>
+<label x="30.48" y="116.84" size="1.778" layer="95"/>
+<pinref part="R24" gate="G$1" pin="2"/>
+</segment>
+<segment>
+<pinref part="J1" gate="G$1" pin="IO19"/>
+<wire x1="20.32" y1="63.5" x2="33.02" y2="63.5" width="0.1524" layer="91"/>
+<label x="20.32" y="63.5" size="1.778" layer="95"/>
 </segment>
 </net>
 </nets>


### PR DESCRIPTION
Adds connections on the PCB for the touch screen connectors on the LCD breakout board. Some pin connections were changed to free up enough pins for this addition.